### PR TITLE
Allow insecureHTTPParser in API requests to Reverso

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -34,3 +34,15 @@ reverso.getTranslation(
         console.log(response)
     }
 )
+
+const reversoInsecureHTTPParser = new Reverso({ insecureHTTPParser: true })
+reversoInsecureHTTPParser.getContext(
+    'see you later',
+    'english',
+    'dutch',
+    (err, response) => {
+        if (err) throw new Error(err.message)
+
+        console.log(response)
+    }
+)

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "author": "Vyacheslav <slava021323@gmail.com>",
     "license": "MIT",
     "dependencies": {
-        "axios": "^0.21.1",
+        "axios": "^0.27.2",
         "cheerio": "^1.0.0-rc.5",
         "random-useragent": "^0.5.0"
     },

--- a/src/reverso.js
+++ b/src/reverso.js
@@ -98,7 +98,6 @@ module.exports = class Reverso {
                 [source, target].join('-') +
                 '/' +
                 encodeURIComponent(text),
-            insecureHTTPParser: this.insecureHTTPParser,
         })
 
         const $ = load(data)
@@ -196,7 +195,6 @@ module.exports = class Reverso {
                 '&language=' +
                 languages[source] +
                 '&getCorrectionDetails=true',
-            insecureHTTPParser: this.insecureHTTPParser,
         })
 
         const result = {
@@ -262,7 +260,6 @@ module.exports = class Reverso {
                 languages[source] +
                 '/' +
                 encodeURIComponent(text),
-            insecureHTTPParser: this.insecureHTTPParser,
         })
 
         const $ = load(data)
@@ -385,7 +382,6 @@ module.exports = class Reverso {
                 },
                 to: languages[target],
             },
-            insecureHTTPParser: this.insecureHTTPParser,
         })
 
         const translationEncoded = Buffer.from(data.translation[0]).toString(
@@ -435,7 +431,10 @@ module.exports = class Reverso {
      */
     async request(config) {
         try {
-            const { data } = await axios(config)
+            const { data } = await axios({
+                insecureHTTPParser: this.insecureHTTPParser,
+                ...config,
+            })
 
             return data
         } catch (err) {

--- a/src/reverso.js
+++ b/src/reverso.js
@@ -33,6 +33,25 @@ module.exports = class Reverso {
         'https://voice.reverso.net/RestPronunciation.svc/v1/output=json/GetVoiceStream/'
 
     /**
+     * @private
+     * Whether to use the insecure HTTP parser in Axios.
+     *
+     * This HTTP parser accepts certain headers that do not strictly follow the specification in
+     * https://datatracker.ietf.org/doc/html/rfc2616#section-4.1. The Reverso API occasionally
+     * returns headers that do not end with CRLF. Enable this to support accept these malformed
+     * responses. See https://github.com/axios/axios#request-config
+     */
+    insecureHTTPParser = false
+
+    /**
+     * @public
+     * @param {insecureHTTPParser: boolean}
+     */
+    constructor({ insecureHTTPParser = false } = {}) {
+        this.insecureHTTPParser = insecureHTTPParser
+    }
+
+    /**
      * Get context examples of the query.
      * @public
      * @param text {string}
@@ -79,6 +98,7 @@ module.exports = class Reverso {
                 [source, target].join('-') +
                 '/' +
                 encodeURIComponent(text),
+            insecureHTTPParser: this.insecureHTTPParser,
         })
 
         const $ = load(data)
@@ -176,6 +196,7 @@ module.exports = class Reverso {
                 '&language=' +
                 languages[source] +
                 '&getCorrectionDetails=true',
+            insecureHTTPParser: this.insecureHTTPParser,
         })
 
         const result = {
@@ -241,6 +262,7 @@ module.exports = class Reverso {
                 languages[source] +
                 '/' +
                 encodeURIComponent(text),
+            insecureHTTPParser: this.insecureHTTPParser,
         })
 
         const $ = load(data)
@@ -363,6 +385,7 @@ module.exports = class Reverso {
                 },
                 to: languages[target],
             },
+            insecureHTTPParser: this.insecureHTTPParser,
         })
 
         const translationEncoded = Buffer.from(data.translation[0]).toString(


### PR DESCRIPTION
# What's the change?
This PR introduces a constructor parameter to set the `insecureHTTPParser` flag when using `axios`. See https://github.com/axios/axios#request-config for more details about this flag. This should allow users to bypass potentially bad headers in the response from the Reverso API. Enabling this flag is generally discouraged, but this can be used in the interim to allow some applications to use this library more reliably.

After this change, some requests fail with `Request failed with status code 404`, matching the true behavior of the website.

# How is it tested?
Added a test case to `example/app.js` exercising this pathway.

In my own script, I call the `getContext` API around a hundred times. After making this change, I didn't encounter further problems with it.

This addresses issue #17.