### PR TITLE
Replace spaces in context lookup with +

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -2,7 +2,7 @@ const Reverso = require('../src/reverso.js')
 const reverso = new Reverso()
 
 reverso.getContext(
-    'meet me half way',
+    'meet me halfway',
     'english',
     'russian',
     (err, response) => {

--- a/src/reverso.js
+++ b/src/reverso.js
@@ -78,7 +78,7 @@ module.exports = class Reverso {
                 this.CONTEXT_URL +
                 [source, target].join('-') +
                 '/' +
-                encodeURIComponent(text),
+                encodeURIComponent(text).replace(/%20/g, '+'),
         })
 
         const $ = load(data)


### PR DESCRIPTION
# What is this change?
This PR replaces %20 with + after url encoding the query for a context lookup. This minimizes the number of requests made to Reverso. It may also help somewhat with Reverso rate limiting.

# How is it tested?
With Wireshark.
Before:
<img width="1527" alt="Screenshot 2022-07-23 at 15 14 17" src="https://user-images.githubusercontent.com/1850319/180606968-21a25c36-a721-4515-9f55-96d0b1dd552f.png">

After:
<img width="1528" alt="Screenshot 2022-07-23 at 15 15 14" src="https://user-images.githubusercontent.com/1850319/180606979-39a023c3-1885-4670-9d42-aeee3aa46bed.png">

This PR fixes #19.