### PR TITLE
Add relevant information in synonym response

### DIFF
--- a/src/reverso.js
+++ b/src/reverso.js
@@ -286,7 +286,7 @@ module.exports = class Reverso {
             synonyms.push({
                 id: i,
                 synonym: $(e).text(),
-                isRelevant: e.classList.contains('relevant'),
+                isRelevant: $(e).attr('class').includes('relevant'),
             });
         })
 

--- a/src/reverso.js
+++ b/src/reverso.js
@@ -282,11 +282,12 @@ module.exports = class Reverso {
 
         const synonyms = []
 
-        $('a.synonym.relevant').each((i, e) => {
+        $('a.synonym').each((i, e) => {
             synonyms.push({
                 id: i,
                 synonym: $(e).text(),
-            })
+                isRelevant: e.classList.contains('relevant'),
+            });
         })
 
         const result = {


### PR DESCRIPTION
Hi,
It could be useful to get all synonyms, including less-relevant words. This PR suggests to add a property "isRelevant" in the response, so the developer could filter results.