### PR TITLE
Add declaration files for TypeScript support

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -1,0 +1,28 @@
+declare module 'reverso-api' {
+  global {
+    export interface ReversoResponse {
+      ok: boolean,
+      text: string,
+      source: string,
+      target: string,
+      translation: string[],
+      examples: {
+        id: number,
+        source: string,
+        target: string,
+      }[]
+    }
+
+    export interface ReversoErrorResponse {
+      ok: boolean,
+      message: string,
+    }
+  }
+
+  type CallbackFunction = (error: ReversoErrorResponse, response: ReversoResponse) => void;
+
+  export default class Reverso {
+    constructor({ insecureHTTPParser = false }?: { insecureHTTPParser: boolean });
+    getContext(text: string, source: string, target: string, callback?: CallbackFunction): ReversoResponse;
+  }
+}

--- a/@types/reverso-api-tests.ts
+++ b/@types/reverso-api-tests.ts
@@ -1,0 +1,12 @@
+import Reverso from 'reverso-api';
+
+const reverso = new Reverso();
+
+export async function getContext(text: string, source: string, target: string): Promise<ReversoResponse> {
+  try {
+    const response = await reverso.getContext(text, source, target);
+    return response;
+  } catch (error) {
+    throw error;
+  }
+}

--- a/@types/tsconfig.json
+++ b/@types/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": [
+      "es6"
+    ],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictFunctionTypes": true,
+    "strictNullChecks": true,
+    "baseUrl": "../",
+    "typeRoots": [
+      "./"
+    ],
+    "types": [],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+    "index.d.ts",
+    "reverso-api-tests.ts"
+  ]
+}

--- a/@types/tslint.json
+++ b/@types/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "version": "2.22.3",
     "description": "Unofficial Reverso API",
     "main": "index.js",
+    "types": "@types/index.d.ts",
     "homepage": "https://github.com/s0ftik3/reverso-api#readme",
     "repository": "https://github.com/s0ftik3/reverso-api",
     "scripts": {


### PR DESCRIPTION
My TypeScript project needed to use `getContext` feature so I write a declaration for it inside `@types` folder and indicate this in `package.json`.

Without it, we always will get an error (Could not find a declaration file for this module) when importing `reverso-api` in a TypeScript file.


Reference: [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped)
| File          | Purpose |
| ------------- | ------- |
| `index.d.ts`  | This contains the typings for the package. |
| `reverso-api-tests.ts` | This contains sample code which tests the typings. This code does *not* run, but it is type-checked. |
| `tsconfig.json` | This allows you to run `tsc` within the package. |
| `tslint.json` | Enables linting. |
| `.eslintrc.json`  | (Rarely) Needed only to disable lint rules written for eslint. |