### PR TITLE
Fix wrong documentation for translation field

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Response:
     text: String,
     source: String,
     target: String,
-    translation: [String, ...],
+    translations: [String, ...],
     examples: [
         {
             id: Number,


### PR DESCRIPTION
PR is self explanatory -- the actual value is `translations`