### PR TITLE
Unhandled exceptions catch + conjugation adaption for French

### DIFF
--- a/src/reverso.js
+++ b/src/reverso.js
@@ -93,14 +93,21 @@ module.exports = class Reverso {
             return error
         }
 
-        const data = await this.#request({
-            method: 'GET',
-            url:
-                this.CONTEXT_URL +
-                [source, target].join('-') +
-                '/' +
-                encodeURIComponent(text).replace(/%20/g, '+'),
-        })
+        let data = null;
+        try {
+            data = await this.#request({
+                method: 'GET',
+                url:
+                    this.CONTEXT_URL +
+                    [source, target].join('-') +
+                    '/' +
+                    encodeURIComponent(text).replace(/%20/g, '+'),
+            })
+        }
+        catch (error) {
+            if (cb) cb(error)
+            return error;
+        }
 
         const $ = load(data)
         const sourceDirection =
@@ -188,19 +195,26 @@ module.exports = class Reverso {
             french: 'fra',
         }
 
-        const data = await this.#request({
-            method: 'POST',
-            url: this.SPELLCHECK_URL,
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            data: {
-                language: languages[source],
-                getCorrectionDetails: true,
-                origin: 'interactive',
-                text,
-            },
-        })
+        let data = null;
+        try {
+            data = await this.#request({
+                method: 'POST',
+                url: this.SPELLCHECK_URL,
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                data: {
+                    language: languages[source],
+                    getCorrectionDetails: true,
+                    origin: 'interactive',
+                    text,
+                },
+            })
+        }
+        catch (error) {
+            if (cb) cb(error)
+            return error;
+        }
 
         if (!data || !Object.keys(data).length) {
             const error = {
@@ -272,14 +286,21 @@ module.exports = class Reverso {
             spanish: 'es',
         }
 
-        const data = await this.#request({
-            method: 'GET',
-            url:
-                this.SYNONYMS_URL +
-                languages[source] +
-                '/' +
-                encodeURIComponent(text),
-        })
+        let data = null;
+        try {
+            data = await this.#request({
+                method: 'GET',
+                url:
+                    this.SYNONYMS_URL +
+                    languages[source] +
+                    '/' +
+                    encodeURIComponent(text),
+            })
+        }
+        catch (error) {
+            if (cb) cb(error)
+            return error;
+        }
 
         const $ = load(data)
 
@@ -383,25 +404,32 @@ module.exports = class Reverso {
             english: 'Heather22k',
         }
 
-        const data = await this.#request({
-            method: 'POST',
-            url: this.TRANSLATION_URL,
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            data: {
-                format: 'text',
-                from: languages[source],
-                input: text,
-                options: {
-                    contextResults: true,
-                    languageDetection: true,
-                    origin: 'reversomobile',
-                    sentenceSplitter: false,
+        let data = null;
+        try {
+            data = await this.#request({
+                method: 'POST',
+                url: this.TRANSLATION_URL,
+                headers: {
+                    'Content-Type': 'application/json',
                 },
-                to: languages[target],
-            },
-        })
+                data: {
+                    format: 'text',
+                    from: languages[source],
+                    input: text,
+                    options: {
+                        contextResults: true,
+                        languageDetection: true,
+                        origin: 'reversomobile',
+                        sentenceSplitter: false,
+                    },
+                    to: languages[target],
+                },
+            })
+        }
+        catch (error) {
+            if (cb) cb(error)
+            return error;
+        }
 
         const translationEncoded = Buffer.from(data.translation[0]).toString(
             'base64'
@@ -484,15 +512,22 @@ module.exports = class Reverso {
             return error
         }
 
-        const data = await this.#request({
-            method: 'GET',
-            url:
-                this.CONJUGATION_URL +
-                source +
-                '-verb-' +
-                encodeURIComponent(text) +
-                '.html',
-        })
+        let data = null;
+        try {
+            data = await this.#request({
+                method: 'GET',
+                url:
+                    this.CONJUGATION_URL +
+                    source +
+                    '-verb-' +
+                    encodeURIComponent(text) +
+                    '.html',
+            })
+        }
+        catch (error) {
+            if (cb) cb(error)
+            return error;
+        }
 
         const $ = load(data)
 

--- a/src/reverso.js
+++ b/src/reverso.js
@@ -533,7 +533,7 @@ module.exports = class Reverso {
 
         const verbForms = []
 
-        $('div[class="blue-box-wrap"]').each((i, e) => {
+        $('div[class~="blue-box-wrap"]').each((i, e) => {
             const header = $(e).attr('mobile-title').trim()
             const data = []
 
@@ -554,10 +554,19 @@ module.exports = class Reverso {
                     }
                 })
 
+            const preData = [];
+            data.forEach(e => preData.push(""));
+            ["particletxt", "graytxt", "auxgraytxt"].forEach(name => {
+                $(e)
+                    .find(`i[class="${name}"]`)
+                    .each((j, word) => preData[j] += $(word).text())
+            });
+
             verbForms.push({
                 id: i,
                 conjugation: header,
-                verbs: [...new Set(data)],
+                preVerbs: preData,
+                verbs: data,
             })
         })
 


### PR DESCRIPTION
**Commit 0acd3ac:**

Unhandled exceptions (on `await this.#request(...)` not wrapped into a try-catch) result in an exit of nodejs process. Added those try-catch to correctly handle those exception

**Commit 1f562f0 (conjugation modifications):**
1. modification of HTML selector to be able to grab the French "subjonctif"
2. additon of verbs "preData" (pronouns, auxiliaries,...), returned in a preVerbs array of the same size/indexes than the verbForms array
3. removal of Sets when returning data, so each preData correspond to its verbForm (the user will have to filter verForms duplicates himself if needed)