### PR TITLE
New languages supported +fixed documentation for getSpellCheck method

### DIFF
--- a/src/languages/available.js
+++ b/src/languages/available.js
@@ -16,7 +16,12 @@ const available = {
         'chinese',
         'english',
     ],
-    spell: ['english', 'french'],
+    spell: [
+        'english', 
+        'french',
+        'italian',
+        'spanish',
+    ],
     synonyms: [
         'english',
         'russian',
@@ -25,6 +30,12 @@ const available = {
         'french',
         'polish',
         'italian',
+        'arabic',
+        'hebrew',
+        'japanese',
+        'dutch',
+        'portugese',
+        'romanian',
     ],
     translation: [
         'arabic',

--- a/src/reverso.js
+++ b/src/reverso.js
@@ -160,7 +160,7 @@ module.exports = class Reverso {
      * @param text {string}
      * @param source {'english' | 'french' | 'italian' | 'spanish'}
      * @param cb {function}
-     * @returns {Promise<{ok: boolean, message: string}|{ ok: boolean, data: string, sentences: any[], stats: any[], corrections: { id: number, text: string, type: string, explanation: string, corrected: string, suggestions: string}[]}>}
+     * @returns {Promise<{ok: boolean, text: string}|{ ok: boolean, data: string, sentences: any[], stats: any[], corrections: { id: number, text: string, type: string, explanation: string, corrected: string, suggestions: string}[]}>}
      */
     async getSpellCheck(text, source = SupportedLanguages.ENGLISH, cb = null) {
         source = source.toLowerCase()

--- a/src/reverso.js
+++ b/src/reverso.js
@@ -158,7 +158,7 @@ module.exports = class Reverso {
      * Get spell check of the query.
      * @public
      * @param text {string}
-     * @param source {'english' | 'french'}
+     * @param source {'english' | 'french' | 'italian' | 'spanish'}
      * @param cb {function}
      * @returns {Promise<{ok: boolean, message: string}|{ ok: boolean, data: string, sentences: any[], stats: any[], corrections: { id: number, text: string, type: string, explanation: string, corrected: string, suggestions: string}[]}>}
      */
@@ -186,6 +186,8 @@ module.exports = class Reverso {
         const languages = {
             english: 'eng',
             french: 'fra',
+            italian: 'ita',
+            spanish: 'spa'
         }
 
         const data = await this.#request({
@@ -237,7 +239,7 @@ module.exports = class Reverso {
      * Get synonyms of the query.
      * @public
      * @param text {string}
-     * @param source {'english' | 'russian' | 'german' | 'spanish' | 'french' | 'polish' | 'italian'}
+     * @param source {'english' | 'russian' | 'german' | 'spanish' | 'french' | 'polish' | 'italian' | 'arabic' | 'hebrew' | 'japanese' | 'dutch' | 'portugese' | 'romanian'}
      * @param cb {function}
      * @returns {Promise<{ok: boolean, message: string}|{synonyms: { id: number, synonym: string }[], text, source: string}>}
      */
@@ -270,6 +272,12 @@ module.exports = class Reverso {
             italian: 'it',
             polish: 'pl',
             spanish: 'es',
+            arabic: 'ar',
+            hebrew: 'he',
+            japanese: 'ja',
+            dutch: 'nl',
+            portugese: 'pt',
+            romanian: 'ro'
         }
 
         const data = await this.#request({

--- a/src/reverso.js
+++ b/src/reverso.js
@@ -160,7 +160,7 @@ module.exports = class Reverso {
      * @param text {string}
      * @param source {'english' | 'french' | 'italian' | 'spanish'}
      * @param cb {function}
-     * @returns {Promise<{ok: boolean, text: string}|{ ok: boolean, data: string, sentences: any[], stats: any[], corrections: { id: number, text: string, type: string, explanation: string, corrected: string, suggestions: string}[]}>}
+     * @returns {Promise<{ok: boolean, message: string}|{ ok: boolean, text: string, sentences: any[], stats: any[], corrections: { id: number, text: string, type: string, explanation: string, corrected: string, suggestions: string}[]}>}
      */
     async getSpellCheck(text, source = SupportedLanguages.ENGLISH, cb = null) {
         source = source.toLowerCase()


### PR DESCRIPTION
Reverso's Grammar Checker and Synonyms APIs now support new languages : **italian** and **spanish** for the _Grammar Checker_ and **arabic**, **hebrew**, **japanese**, **dutch**, **portugese** and **romanian** for the _Synonyms_.
There are also some new languages for the Translation and Context APIs but I haven't really looked at this yet.

### Commit *d39d9db* : 
Added support to new languages in the Spell Check and Synonyms APIs.

### Commit *aff0399* : 
Fixed wrong documentation in the `reverso.js`'s `getSpellCheck` method : 
Returns 
```javascript
{ ok: boolean, text: string, ...  }
```
instead of 
```javascript
{ ok: boolean, data: string, ...  }
```