### PR TITLE
feat: remove new set to allow duplicates

### DIFF
--- a/src/reverso.js
+++ b/src/reverso.js
@@ -514,7 +514,7 @@ module.exports = class Reverso {
             verbForms.push({
                 id: i,
                 conjugation: header,
-                verbs: [...new Set(data)],
+                verbs: data,
             })
         })
 


### PR DESCRIPTION
In many languages some verbs might be the same when conjugated for different persons and also in tenses. There is a need of having a full list of verbs even though they are repeated, to create tables just like in [their web site](https://conjugator.reverso.net/conjugation-german-verb-gehen.html). This is why I think removing the new Set is good, to have the full list, and then we can manually add the pronouns.