### PR TITLE
Escaping of non-Latin chars during Base64 conversion

### DIFF
--- a/src/utils/to-base64.js
+++ b/src/utils/to-base64.js
@@ -6,7 +6,7 @@ function toBase64(str) {
     if (typeof Buffer !== 'undefined') {
         return Buffer.from(str).toString('base64')
     } else {
-        return btoa(str)
+        return btoa(String.fromCharCode(...new TextEncoder().encode((str))))
     }
 }
 


### PR DESCRIPTION
Hello again! [In my previous PR](https://github.com/s0ftik3/reverso-api/pull/37/files#diff-1590485e9135909372603a067160fd70f29399fc36d7a42fb7a27667eece605cR391) there was also code for escaping non-Latin characters. Since `response.data.translation[0]` can have text in other languages and `btoa` cannot work with non-Latin characters, there is an error in your code for a browser (or a React native app).
![Screenshot from 2024-08-01 13-12-39](https://github.com/user-attachments/assets/c40b56aa-b155-486b-a0c7-153af46075c5)
![Screenshot_1722503871](https://github.com/user-attachments/assets/edd9e529-2757-4916-85a4-1836f8bd7371)
