### PR TITLE
A voice link for the source text

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,8 @@ Response:
         rude: Boolean
     }, // or null
     detected_language: String,
-    voice: String // or null
+    voice: String, // or null
+    sourceVoice: String // or null
 }
 ```
 

--- a/src/reverso.js
+++ b/src/reverso.js
@@ -407,6 +407,9 @@ module.exports = class Reverso {
                 voices[target] && response.data.translation[0].length <= 150
                     ? `${this.VOICE_URL}voiceName=${voices[target]}?inputText=${translationEncoded}`
                     : null,
+            sourceVoice: voices[source] && text.length <= 150
+                    ? `${this.VOICE_URL}voiceName=${voices[target]}?inputText=${toBase64(text)}`
+                    : null,
         }
 
         if (response.data.contextResults?.results) {


### PR DESCRIPTION
Hello @s0ftik3! I see that your API only provides speech for the translation, but in my opinion it should also provide speech for the source text. For example, if I see an unfamiliar word in a book, I translate it into my native language, and in this case I want to hear the sound of the input text, not the translation.  Also, most translation tools provide sound for both the input text and the translation.
![Screenshot 2024-08-01 at 15-45-50 Reverso Free translation dictionary](https://github.com/user-attachments/assets/03cdacb2-9390-4286-99b9-7ab5dbeaac34)
